### PR TITLE
remove copy.deepcopy

### DIFF
--- a/atomos/__about__.py
+++ b/atomos/__about__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 __title__ = 'atomos'
-__version_info__ = ('0', '1', '0')
+__version_info__ = ('0', '2', '0')
 __version__ = '.'.join(__version_info__)
 __author__ = 'Max Countryman'
 __license__ = 'BSD'

--- a/atomos/atomic.py
+++ b/atomos/atomic.py
@@ -5,7 +5,6 @@ atomos.atomic
 Atomic primitives.
 '''
 
-import copy
 import types
 
 import atomos.util as util
@@ -49,7 +48,7 @@ class AtomicReference(object):
         :param value: The value to set.
         '''
         with self._lock.exclusive:
-            oldval = copy.deepcopy(self._value)
+            oldval = self._value
             self._value = value
             return oldval
 


### PR DESCRIPTION
This removes uses of copy.deepcopy which proved problematic when dealing
with certain kinds of objects. However it is worth noting that the
original intention of deepcopy was to provide some protection against
accidental mutation of shared object references. In particular, if a
function passed to Atom.swap mutates the reference to oldval then it can
loop indefinitely! Callers are now responsible for ensuring this does
not happen. Additionally watches are affected because they are passed
the same references to oldval and newval; likewise they must take care
to not mutate these references. Instead in either case the reference
should be copied or in some way used without mutating the shared
reference. Note that persistent data structures are one method for
dealing with this problem.
