### PR TITLE
[WIP]Add support to run tests agains Python 3 using tox and multiprocessing support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,46 @@
-*.pyc
-*.egg-info
+# Backup files
+*.~
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+bin/
+build/
+develop-eggs/
+dist/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+.eggs
+MANIFEST
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+
+# Sphinx documentation
+docs/_build/
+
+# vim
+*.swp

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+clean:
+	@find . -iname '*.pyc' -delete
+	@find . -iname '*.pyo' -delete
+	@find . -iname '*~' -delete
+	@find . -iname '*.swp' -delete
+	@find . -iname '__pycache__' -delete
+
+cleaneggs:
+	@find . -name '*.egg' -print0|xargs -0 rm -rf --
+	@rm -rf .eggs/

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Now it works with [multiprocessing](https://docs.python.org/3.4/library/multipro
 
 Just use the following import path:
 
-```
+```python
 import atomos.multiprocessing.atomic
 ```
 

--- a/README.md
+++ b/README.md
@@ -97,9 +97,13 @@ So long as we interact with the `MyState` instance via the `state` wrapper, our
 updates will always be protected.
 
 ## Multiprocessing
-Please note that at this time these data structures will not play nice with
-multiprocessing. This is due to the fact that state-sharing between processes
-generally requires pickle-able objects.
+Now it works with [multiprocessing](https://docs.python.org/3.4/library/multiprocessing.html).
+
+Just use the following import path:
+
+```
+import atomos.multiprocessing.atomic
+```
 
 ## Contribution
 Contributions are welcome, please ensure PEP8 is followed and that new code is

--- a/atomos/atomic.py
+++ b/atomos/atomic.py
@@ -162,7 +162,7 @@ class AtomicInteger(AtomicNumber):
 
     def __setattr__(self, name, value):
         # Ensure the `_value` attribute is always an int.
-        if name == '_value' and not isinstance(value, int):
+        if name == '_value' and not isinstance(value, types.IntType):
             raise TypeError('_value must be of type int')
 
         super(AtomicInteger, self).__setattr__(name, value)
@@ -192,7 +192,7 @@ class AtomicFloat(AtomicNumber):
 
     def __setattr__(self, name, value):
         # Ensure the `_value` attribute is always a float.
-        if name == '_value' and not isinstance(value, float):
+        if name == '_value' and not isinstance(value, types.FloatType):
             raise TypeError('_value must be of type float')
 
         super(AtomicFloat, self).__setattr__(name, value)

--- a/atomos/atomic.py
+++ b/atomos/atomic.py
@@ -162,7 +162,7 @@ class AtomicInteger(AtomicNumber):
 
     def __setattr__(self, name, value):
         # Ensure the `_value` attribute is always an int.
-        if name == '_value' and not isinstance(value, types.IntType):
+        if name == '_value' and not isinstance(value, int):
             raise TypeError('_value must be of type int')
 
         super(AtomicInteger, self).__setattr__(name, value)

--- a/atomos/atomic.py
+++ b/atomos/atomic.py
@@ -7,7 +7,12 @@ Atomic primitives.
 
 import types
 
+import six
+
 import atomos.util as util
+
+if six.PY3:
+    long = int
 
 
 class AtomicReference(object):
@@ -157,7 +162,7 @@ class AtomicInteger(AtomicNumber):
 
     def __setattr__(self, name, value):
         # Ensure the `_value` attribute is always an int.
-        if name == '_value' and not isinstance(value, types.IntType):
+        if name == '_value' and not isinstance(value, int):
             raise TypeError('_value must be of type int')
 
         super(AtomicInteger, self).__setattr__(name, value)
@@ -172,7 +177,7 @@ class AtomicLong(AtomicNumber):
 
     def __setattr__(self, name, value):
         # Ensure the `_value` attribute is always a long.
-        if name == '_value' and not isinstance(value, types.LongType):
+        if name == '_value' and not isinstance(value, long):
             raise TypeError('_value must be of type long')
 
         super(AtomicLong, self).__setattr__(name, value)
@@ -187,7 +192,7 @@ class AtomicFloat(AtomicNumber):
 
     def __setattr__(self, name, value):
         # Ensure the `_value` attribute is always a float.
-        if name == '_value' and not isinstance(value, types.FloatType):
+        if name == '_value' and not isinstance(value, float):
             raise TypeError('_value must be of type float')
 
         super(AtomicFloat, self).__setattr__(name, value)

--- a/atomos/multiprocessing/atomic.py
+++ b/atomos/multiprocessing/atomic.py
@@ -27,7 +27,7 @@ class AtomicReference(ThreadedAtomicReference):
     '''
     def __init__(self, value=None):
         super(AtomicReference, self).__init__(value=value)
-        self._lock = util.ReadersWriterLock(use_multiprocessing=True)
+        self._lock = util.ReadersWriterLockMultiprocessing()
 
 
 class AtomicCtypesReference(object):

--- a/atomos/multiprocessing/atomic.py
+++ b/atomos/multiprocessing/atomic.py
@@ -1,0 +1,202 @@
+# -*- coding: utf-8 -*-
+'''
+atomos.multiprocessing.atomic
+
+Atomic primitives multiprocessing.
+'''
+
+import types
+import ctypes
+from multiprocessing import Value
+
+import six
+
+import atomos.util as util
+
+if six.PY3:
+    long = int
+
+
+# TODO: Fix it to work with other types
+# https://docs.python.org/3.4/library/ctypes.html#fundamental-data-types
+class AtomicReference(object):
+    '''
+    A reference to an object which allows atomic manipulation semantics.
+
+    AtomicReferences are particularlly useful when an object cannot otherwise
+    be manipulated atomically.
+    '''
+    def __init__(self, typecode=None, value=None):
+        self._typecode = typecode
+        self._reference = Value(self._typecode, value)
+
+    def __repr__(self):
+        return util.repr(__name__, self, self._reference)
+
+    def get(self):
+        '''
+        Returns the value.
+        '''
+        with self._reference.get_lock():
+            return self._reference.value
+
+    def set(self, value):
+        '''
+        Atomically sets the value to `value`.
+
+        :param value: The value to set.
+        '''
+        with self._reference.get_lock():
+            self._reference.value = value
+            return value
+
+    def get_and_set(self, value):
+        '''
+        Atomically sets the value to `value` and returns the old value.
+
+        :param value: The value to set.
+        '''
+        with self._reference.get_lock():
+            oldval = self._reference.value
+            self._reference.value = value
+            return oldval
+
+    def compare_and_set(self, expect, update):
+        '''
+        Atomically sets the value to `update` if the current value is equal to
+        `expect`.
+
+        :param expect: The expected current value.
+        :param update: The value to set if and only if `expect` equals the
+        current value.
+        '''
+        with self._reference.get_lock():
+            if self._reference.value == expect:
+                self._reference.value = update
+                return True
+
+            return False
+
+
+class AtomicBoolean(AtomicReference):
+    '''
+    A boolean value whichs allows atomic manipulation semantics.
+    '''
+    def __init__(self, value=False):
+        super(AtomicBoolean, self).__init__(typecode=ctypes.c_bool, value=value)
+
+    # We do not need a locked get since a boolean is not a complex data type.
+    def get(self):
+        '''
+        Returns the value.
+        '''
+        return self._reference.value
+
+    def __setattr__(self, name, value):
+        # Ensure the `value` attribute is always a bool.
+        if name == '_value' and not isinstance(value, types.BooleanType):
+            raise TypeError('_value must be of type bool')
+
+        super(AtomicBoolean, self).__setattr__(name, value)
+
+
+class AtomicNumber(AtomicReference):
+    '''
+    AtomicNumber object super type.
+
+    Contains common methods for AtomicInteger, AtomicLong, and AtomicFloat.
+    '''
+    # We do not need a locked get since numbers are not complex data types.
+    def get(self):
+        '''
+        Returns the value.
+        '''
+        return self._reference.value
+
+    def add_and_get(self, delta):
+        '''
+        Atomically adds `delta` to the current value.
+
+        :param delta: The delta to add.
+        '''
+        with self._reference.get_lock():
+            self._reference.value += delta
+            return self._reference.value
+
+    def get_and_add(self, delta):
+        '''
+        Atomically adds `delta` to the current value and returns the old value.
+
+        :param delta: The delta to add.
+        '''
+        with self._reference.get_lock():
+            oldval = self._reference.value
+            self._reference.value += delta
+            return oldval
+
+    def subtract_and_get(self, delta):
+        '''
+        Atomically subtracts `delta` from the current value.
+
+        :param delta: The delta to subtract.
+        '''
+        with self._reference.get_lock():
+            self._reference.value -= delta
+            return self._reference.value
+
+    def get_and_subtract(self, delta):
+        '''
+        Atomically subtracts `delta` from the current value and returns the
+        old value.
+
+        :param delta: The delta to subtract.
+        '''
+        with self._reference.get_lock():
+            oldval = self._reference.value
+            self._reference.value -= delta
+            return oldval
+
+
+class AtomicInteger(AtomicNumber):
+    '''
+    An integer value which allows atomic manipulation semantics.
+    '''
+    def __init__(self, value=0):
+        super(AtomicInteger, self).__init__(typecode=ctypes.c_int, value=value)
+
+    def __setattr__(self, name, value):
+        # Ensure the `_value` attribute is always an int.
+        if name == '_value' and not isinstance(value, int):
+            raise TypeError('_value must be of type int')
+
+        super(AtomicInteger, self).__setattr__(name, value)
+
+
+class AtomicLong(AtomicNumber):
+    '''
+    A long value which allows atomic manipulation semantics.
+    '''
+    def __init__(self, value=long(0)):
+        super(AtomicLong, self).__init__(typecode=ctypes.c_long, value=value)
+
+    def __setattr__(self, name, value):
+        # Ensure the `_value` attribute is always a long.
+        if name == '_value' and not isinstance(value, long):
+            raise TypeError('_value must be of type long')
+
+        super(AtomicLong, self).__setattr__(name, value)
+
+
+class AtomicFloat(AtomicNumber):
+    '''
+    A float value which allows atomic manipulation semantics.
+    '''
+    def __init__(self, value=float(0)):
+        super(AtomicFloat, self).__init__(typecode=ctypes.c_float, value=value)
+
+    def __setattr__(self, name, value):
+        # Ensure the `_value` attribute is always a float.
+        if name == '_value' and not isinstance(value, float):
+            raise TypeError('_value must be of type float')
+
+        super(AtomicFloat, self).__setattr__(name, value)

--- a/atomos/util.py
+++ b/atomos/util.py
@@ -4,9 +4,10 @@ atomos.util
 
 Utility functions.
 '''
-
+from __future__ import absolute_import
 import functools
 import threading
+import multiprocessing
 
 
 def repr(module, instance, value):
@@ -77,9 +78,19 @@ class ReadersWriterLock(object):
     fact an attempt to acquire it will block until all the readers have
     released the lock.
     '''
-    def __init__(self):
-        self._reader_lock = threading.Lock()
-        self._writer_lock = threading.Lock()
+    def __init__(self, use_multiprocessing=False):
+        '''
+        Readers writer lock
+
+        :param use_multiprocessing: Use multiprocessing instead threading.
+        '''
+        if use_multiprocessing:
+            self._reader_lock = multiprocessing.Lock()
+            self._writer_lock = multiprocessing.Lock()
+        else:
+            self._reader_lock = threading.Lock()
+            self._writer_lock = threading.Lock()
+
         self._reader_count = 0
 
         class SharedLock(object):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,8 @@ import os
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('..'))
 
 # -- General configuration ------------------------------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,3 +48,20 @@ API
 
 .. autoclass:: atomos.atomic.AtomicFloat
     :members:
+
+API Multiprocessing
+===================
+.. autoclass:: atomos.multiprocessing.atomic.AtomicReference
+    :members:
+
+.. autoclass:: atomos.multiprocessing.atomic.AtomicBoolean
+    :members:
+
+.. autoclass:: atomos.multiprocessing.atomic.AtomicInteger
+    :members:
+
+.. autoclass:: atomos.multiprocessing.atomic.AtomicLong
+    :members:
+
+.. autoclass:: atomos.multiprocessing.atomic.AtomicFloat
+    :members:

--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,33 @@ Links
 * `development version <https://github.com/maxcountryman/atomos>`_
 '''
 
+import sys
+
 import setuptools
+from setuptools.command.test import test as TestCommand
+
 
 about = {}
 with open('atomos/__about__.py') as f:
     exec(f.read(), about)
+
+setup_requires = ['pytest', 'tox']
+install_requires = ['six', 'tox']
+tests_require = ['pytest-cov', 'pytest-cache', 'pytest-timeout']
+
+
+class PyTest(TestCommand):
+    def finalize_options(self):
+        TestCommand.finalize_options(self)
+        self.test_args = ['--strict', '--verbose', '--tb=long',
+                          '--cov', 'atomos', '--cov-report',
+                          'term-missing', 'tests']
+        self.test_suite = True
+
+    def run_tests(self):
+        import pytest
+        errno = pytest.main(self.test_args)
+        sys.exit(errno)
 
 setuptools.setup(name=about['__title__'],
                  version=about['__version__'],
@@ -32,4 +54,8 @@ setuptools.setup(name=about['__title__'],
                               'Programming Language :: Python',
                               'Topic :: Utilities',
                               'License :: OSI Approved :: BSD License'],
+                 cmdclass={'test': PyTest},
+                 setup_requires=setup_requires,
+                 install_requires=install_requires,
+                 tests_require=tests_require,
                  zip_safe=False)

--- a/tests/test_aref.py
+++ b/tests/test_aref.py
@@ -2,7 +2,7 @@
 '''
 tests.test_aref
 '''
-
+import six
 import pytest
 
 import atomos.atom
@@ -24,7 +24,7 @@ def test_aref_add_watch(aref):
     aref.add_watch('foo', watch)
 
     assert 'foo' in aref.get_watches()
-    assert watch in aref.get_watches().itervalues()
+    assert watch in six.itervalues(aref.get_watches())
 
 
 def test_aref_remove_watch(aref):
@@ -35,7 +35,7 @@ def test_aref_remove_watch(aref):
     aref.remove_watch('foo')
 
     assert 'foo' not in aref.get_watches()
-    assert watch not in aref.get_watches().itervalues()
+    assert watch not in six.itervalues(aref.get_watches())
 
 
 def test_aref_notify_watches(aref):

--- a/tests/test_multiprocessing_atomic.py
+++ b/tests/test_multiprocessing_atomic.py
@@ -10,22 +10,20 @@ import pytest
 import atomos.multiprocessing.atomic
 
 
-"""
 @pytest.fixture
 def atomic_reference():
     return atomos.multiprocessing.atomic.AtomicReference({})
-"""
 
 
 @pytest.fixture
 def atomic_number():
     class TestNumber(atomos.multiprocessing.atomic.AtomicNumber):
         def __init__(self, value=0):
-            super(TestNumber, self).__init__(typecode='i', value=value)
+            super(TestNumber, self).__init__(typecode_or_type='i', value=value)
 
     return TestNumber()
 
-"""
+
 def test_atomic_reference_get(atomic_reference):
     assert atomic_reference.get() == {}
 
@@ -46,7 +44,6 @@ def test_atomic_reference_get_and_set(atomic_reference):
 def test_atomic_reference_compare_and_set(atomic_reference):
     assert atomic_reference.compare_and_set({}, {'foo': 'bar'}) is True
     assert atomic_reference.compare_and_set({}, {'foo', 'bar'}) is False
-"""
 
 
 def test_atomic_number_add_and_get(atomic_number):

--- a/tests/test_multiprocessing_atomic.py
+++ b/tests/test_multiprocessing_atomic.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+'''
+tests.test_atomic
+'''
+
+from multiprocessing import Process
+
+import pytest
+
+import atomos.multiprocessing.atomic
+
+
+"""
+@pytest.fixture
+def atomic_reference():
+    return atomos.multiprocessing.atomic.AtomicReference({})
+"""
+
+
+@pytest.fixture
+def atomic_number():
+    class TestNumber(atomos.multiprocessing.atomic.AtomicNumber):
+        def __init__(self, value=0):
+            super(TestNumber, self).__init__(typecode='i', value=value)
+
+    return TestNumber()
+
+"""
+def test_atomic_reference_get(atomic_reference):
+    assert atomic_reference.get() == {}
+
+
+def test_atomic_reference_set(atomic_reference):
+    atomic_reference.set({'foo': 'bar'})
+
+    assert atomic_reference.get() == {'foo': 'bar'}
+
+
+def test_atomic_reference_get_and_set(atomic_reference):
+    ret = atomic_reference.get_and_set({'foo': 'bar'})
+
+    assert atomic_reference.get() == {'foo': 'bar'}
+    assert ret == {}
+
+
+def test_atomic_reference_compare_and_set(atomic_reference):
+    assert atomic_reference.compare_and_set({}, {'foo': 'bar'}) is True
+    assert atomic_reference.compare_and_set({}, {'foo', 'bar'}) is False
+"""
+
+
+def test_atomic_number_add_and_get(atomic_number):
+    assert atomic_number.add_and_get(1) == 1
+
+
+def test_atomic_number_get_and_add(atomic_number):
+    assert atomic_number.get_and_add(1) == 0
+
+
+def test_atomic_number_subtract_and_get(atomic_number):
+    assert atomic_number.subtract_and_get(1) == -1
+
+
+def test_atomic_number_get_and_subtract(atomic_number):
+    assert atomic_number.get_and_subtract(1) == 0
+
+
+def test_concurrent_atomic_int(process_count=10, loop_count=1000):
+    atomic_int = atomos.multiprocessing.atomic.AtomicInteger()
+
+    def inc_atomic_int():
+        for _ in range(loop_count):
+            atomic_int.add_and_get(1)
+
+    processes = []
+    for _ in range(process_count):
+        p = Process(target=inc_atomic_int)
+        processes.append(p)
+        p.start()
+
+    for p in processes:
+        p.join()
+
+    assert atomic_int.get() == process_count * loop_count

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -95,12 +95,12 @@ def test_readers_writer_lock(acquire_shared_count=10):
 
 # TODO: Make this test pass
 def test_readers_writer_lock_multiprocessing(acquire_shared_count=10):
-    lock = atomos.util.ReadersWriterLock(use_multiprocessing=True)
+    lock = atomos.util.ReadersWriterLockMultiprocessing()
 
     for _ in range(acquire_shared_count):
         lock.shared.acquire()
 
-    assert lock._reader_count == acquire_shared_count
+    assert lock._reader_count.value == acquire_shared_count
 
     # Cannot acquire an exclusive lock with active readers.
     p = multiprocessing.Process(target=lock.exclusive.acquire)
@@ -113,7 +113,7 @@ def test_readers_writer_lock_multiprocessing(acquire_shared_count=10):
     for _ in range(acquire_shared_count):
         lock.shared.release()
 
-    assert lock._reader_count == 0
+    assert lock._reader_count.value == 0
 
     p.join()
 
@@ -149,4 +149,4 @@ def test_readers_writer_lock_multiprocessing(acquire_shared_count=10):
     p.join()
 
     assert p.is_alive() is False
-    assert lock._reader_count == 1
+    assert lock._reader_count.value == 1

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -4,6 +4,7 @@ tests.test_util
 '''
 
 import threading
+import multiprocessing
 
 import atomos.util
 
@@ -89,4 +90,63 @@ def test_readers_writer_lock(acquire_shared_count=10):
     t.join()
 
     assert t.is_alive() is False
+    assert lock._reader_count == 1
+
+
+# TODO: Make this test pass
+def test_readers_writer_lock_multiprocessing(acquire_shared_count=10):
+    lock = atomos.util.ReadersWriterLock(use_multiprocessing=True)
+
+    for _ in range(acquire_shared_count):
+        lock.shared.acquire()
+
+    assert lock._reader_count == acquire_shared_count
+
+    # Cannot acquire an exclusive lock with active readers.
+    p = multiprocessing.Process(target=lock.exclusive.acquire)
+    p.start()
+
+    p.join(1.0)
+
+    assert p.is_alive() is True
+
+    for _ in range(acquire_shared_count):
+        lock.shared.release()
+
+    assert lock._reader_count == 0
+
+    p.join()
+
+    assert p.is_alive() is False
+
+    # Cannot acquire an exclusive lock with an active writer. (This was
+    # acquired in the above process.
+    p = multiprocessing.Process(target=lock.exclusive.acquire)
+    p.start()
+
+    p.join(1.0)
+
+    assert p.is_alive() is True
+
+    # Release the original acquisition.
+    lock.exclusive.release()
+
+    p.join()
+
+    assert p.is_alive() is False
+
+    # Cannot acquire a shared lock with an active writer. (This was acquired
+    # in the above process.)
+    p = multiprocessing.Process(target=lock.shared.acquire)
+    p.start()
+
+    p.join(1.0)
+
+    assert p.is_alive() is True
+
+    lock.exclusive.release()
+
+    p.join()
+
+    assert p.is_alive() is False
     assert lock._reader_count == 1

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -93,7 +93,6 @@ def test_readers_writer_lock(acquire_shared_count=10):
     assert lock._reader_count == 1
 
 
-# TODO: Make this test pass
 def test_readers_writer_lock_multiprocessing(acquire_shared_count=10):
     lock = atomos.util.ReadersWriterLockMultiprocessing()
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+[tox]
+envlist = py27,py32,py33,py34,pypy
+
+[testenv]
+commands = python setup.py test
+
+[testenv:py27]
+basepython = python2.7
+
+[testenv:py32]
+basepython = python3.2
+
+[testenv:py33]
+basepython = python3.3
+
+[testenv:pypy]
+basepython = pypy


### PR DESCRIPTION
My plan was to open two PR one to add Python 3 test support and another with multiprocessing support
but it seems not possible.

This adds:

* `python setup.py test` command.
* `tox` command.

Examples:

```python
>>> import atomos.multiprocessing.atomic
>>> counter = atomos.multiprocessing.atomic.AtomicInteger()
>>> counter.get()
0
```

and 

```python
from multiprocessing import Process

process_count=10
loop_count=1000

atomic_int = atomos.multiprocessing.atomic.AtomicInteger()

def inc_atomic_int():
    for _ in range(loop_count):
        atomic_int.add_and_get(1)

processes = []
for _ in range(process_count):
    p = Process(target=inc_atomic_int)
    processes.append(p)
    p.start()
```