### PR TITLE
Fix setup.py to include multiprocessing module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ pip-delete-this-directory.txt
 
 # Unit test / coverage reports
 .tox/
-.coverage
+.coverage*
 .cache
 nosetests.xml
 coverage.xml
@@ -44,3 +44,4 @@ docs/_build/
 
 # vim
 *.swp
+*.swo

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include README.md
+include LICENSE
+exclude Makefile
+exclude tox.ini
+prune docs
+prune tests

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,9 @@ clean:
 	@find . -iname '*~' -delete
 	@find . -iname '*.swp' -delete
 	@find . -iname '__pycache__' -delete
+	@rm -rf dist/
 
 cleaneggs:
 	@find . -name '*.egg' -print0|xargs -0 rm -rf --
 	@rm -rf .eggs/
+	@rm -rf *.egg-info/

--- a/atomos/__about__.py
+++ b/atomos/__about__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 __title__ = 'atomos'
-__version_info__ = ('0', '3', '0')
+__version_info__ = ('0', '3', '1')
 __version__ = '.'.join(__version_info__)
 __author__ = 'Max Countryman'
 __license__ = 'BSD'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,17 +45,9 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Atomos'
-copyright = u'2014, Max Countryman'
+copyright = u'2015, Max Countryman'
 
-module_path = os.path.join(os.path.dirname(__file__),
-                           '../atomos',
-                           '__about__.py')
-module_path = os.path.abspath(module_path)
-version_line = filter(lambda l: l.startswith('__version_info__'),
-                      open(module_path))[0]
-
-__version__ = '.'.join(eval(version_line.split('__version_info__ = ')[-1]))
-
+from atomos.__about__ import __version__
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ Links
 
 import sys
 
-import setuptools
+from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
 
@@ -24,6 +24,9 @@ with open('atomos/__about__.py') as f:
 setup_requires = ['pytest', 'tox']
 install_requires = ['six', 'tox']
 tests_require = ['pytest-cov', 'pytest-cache', 'pytest-timeout']
+dev_requires = ['pyflakes', 'pep8', 'pylint', 'check-manifest',
+                'ipython', 'ipdb', 'sphinx']
+dev_requires.append(tests_require)
 
 
 class PyTest(TestCommand):
@@ -39,23 +42,32 @@ class PyTest(TestCommand):
         errno = pytest.main(self.test_args)
         sys.exit(errno)
 
-setuptools.setup(name=about['__title__'],
-                 version=about['__version__'],
-                 author='Max Countryman',
-                 author_email=about['__author__'],
-                 description='Atomic primitives for Python.',
-                 license=about['__license__'],
-                 keywords='atom atomic concurrency lock',
-                 url='https://github.com/maxcountryman/atomos',
-                 packages=['atomos', 'tests'],
-                 long_description=__doc__,
-                 classifiers=['Development Status :: 5 - Production/Stable',
-                              'Intended Audience :: Developers',
-                              'Programming Language :: Python',
-                              'Topic :: Utilities',
-                              'License :: OSI Approved :: BSD License'],
-                 cmdclass={'test': PyTest},
-                 setup_requires=setup_requires,
-                 install_requires=install_requires,
-                 tests_require=tests_require,
-                 zip_safe=False)
+setup(name=about['__title__'],
+      version=about['__version__'],
+      author='Max Countryman',
+      author_email=about['__author__'],
+      description='Atomic primitives for Python.',
+      license=about['__license__'],
+      keywords='atom atomic concurrency lock',
+      url='https://github.com/maxcountryman/atomos',
+      packages=find_packages(exclude=['docs', 'tests']),
+      long_description=__doc__,
+      classifiers=['Development Status :: 5 - Production/Stable',
+                   'Intended Audience :: Developers',
+                   'Programming Language :: Python',
+                   'Programming Language :: Python :: 2',
+                   'Programming Language :: Python :: 2.7',
+                   'Programming Language :: Python :: 3',
+                   'Programming Language :: Python :: 3.3',
+                   'Programming Language :: Python :: 3.4',
+                   'Topic :: Utilities',
+                   'License :: OSI Approved :: BSD License'],
+      cmdclass={'test': PyTest},
+      setup_requires=setup_requires,
+      install_requires=install_requires,
+      tests_require=tests_require,
+      extras_require={
+          'dev': dev_requires,
+          'test': tests_require,
+      },
+      zip_safe=False)

--- a/tests/test_atomic.py
+++ b/tests/test_atomic.py
@@ -5,6 +5,7 @@ tests.test_atomic
 
 import multiprocessing
 import threading
+import ctypes
 
 import pytest
 
@@ -23,9 +24,10 @@ class TestNumberT(atomos.atomic.AtomicNumber):
         self._value = value
 
 
-class TestNumberP(atomos.atomic.AtomicNumber):
+class TestNumberP(atomos.multiprocessing.atomic.AtomicNumber):
     def __init__(self, value=0):
-        super(TestNumberP, self).__init__()
+        super(TestNumberP, self).__init__(typecode_or_type=ctypes.c_int,
+                                          value=value)
         self._value = value
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,pypy
+envlist = py27,py33,py34,pypy,docs
 
 [testenv]
 commands = python setup.py test
@@ -15,3 +15,8 @@ basepython = python3.4
 
 [testenv:pypy]
 basepython = pypy
+
+[testenv:docs]
+changedir=docs
+commands=
+    /usr/bin/make clean html


### PR DESCRIPTION
Version `0.3.0`  do not include `atomos.multiprocessing.atomic` Python package, this pull request changes the way  `setup.py` search for packages to include it in `sdist` command.

Correct version installed:
```bash
$ pip freeze | grep atomos
atomos==0.3.0
```

Import error trying to import multiprocessing:
```python
In [1]: import atomos.multiprocessing.atomic
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-1-7de8f9d056b1> in <module>()
----> 1 import atomos.multiprocessing.atomic

ImportError: No module named 'atomos.multiprocessing'

In [2]: 

```