### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ Atomic primitives for Python.
 
 Links
 `````
-* `documentation <https://atomos.readthedocs.org/en/latest/>`_
+* `documentation <https://atomos.readthedocs.io/en/latest/>`_
 * `development version <https://github.com/maxcountryman/atomos>`_
 '''
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.